### PR TITLE
Add a workflow to autogenerate pot files updates

### DIFF
--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Update po templates
         run: |
           python scripts/02_update_catalogs.py
-      - name: Set branch name
-        run: echo "BRANCH_NAME=pot-update-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Set branch name and get hash
+        run: |
+          echo "BRANCH_NAME=pot-update-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Create a new branch
         run: |
           git checkout -b "${{ env.BRANCH_NAME }}"
@@ -39,7 +41,7 @@ jobs:
           git push --set-upstream origin "${{ env.BRANCH_NAME }}"
       - name: Create a PR
         run: |
-          hub pull-request -m "Update pot files" -m "New changes to pot files were detected."
+          hub pull-request -m "Update pot files" -m "New changes to pot files were detected in ${{ env.COMMIT_SHA }} commit."
         env:
           GITHUB_USER: ${{ secrets.GITHUB_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -1,8 +1,10 @@
 on:
   push:
+    branches:
+      - master
     paths:
       - repository-map.yml
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   update_pot:

--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  update_pot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements/release.txt
+          # temporarily use master version as not yet released
+          python -m pip install git+https://github.com/jupyterlab/jupyterlab-translate
+      - name: Update po templates
+        run: |
+          python scripts/02_update_catalogs.py
+      - name: Create a new branch
+        run: |
+          git checkout -b pot-update-$(git rev-parse --short HEAD)
+      - name: Set up git identity
+        run: |
+          git config user.name "JupyterLab Language Packs Bot"
+          git config --global user.email 'krassowski@users.noreply.github.com'
+      - name: Commit changes
+        run: |
+          git add *.pot
+          git commit -m "Update pot files"
+      - name: Push the changes
+        run: |
+          git push -u
+      - name: Create a PR
+        run: |
+          hub pull-request -m "Update pot files"

--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -37,3 +37,7 @@ jobs:
       - name: Create a PR
         run: |
           hub pull-request -m "Update pot files"
+        env:
+          GITHUB_USER: ${{ secrets.GITHUB_USER }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -1,6 +1,5 @@
 on:
   push:
-  pull_request:
 
 jobs:
   update_pot:
@@ -19,9 +18,11 @@ jobs:
       - name: Update po templates
         run: |
           python scripts/02_update_catalogs.py
+      - name: Set branch name
+        run: echo "BRANCH_NAME=pot-update-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Create a new branch
         run: |
-          git checkout -b pot-update-$(git rev-parse --short HEAD)
+          git checkout -b "${{ env.BRANCH_NAME }}"
       - name: Set up git identity
         run: |
           git config user.name "JupyterLab Language Packs Bot"
@@ -32,7 +33,7 @@ jobs:
           git commit -m "Update pot files"
       - name: Push the changes
         run: |
-          git push -u
+          git push --set-upstream origin "${{ env.BRANCH_NAME }}"
       - name: Create a PR
         run: |
           hub pull-request -m "Update pot files"

--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -1,5 +1,8 @@
 on:
   push:
+    paths:
+      - repository-map.yml
+    workflow_dispatch:
 
 jobs:
   update_pot:
@@ -26,7 +29,7 @@ jobs:
       - name: Set up git identity
         run: |
           git config user.name "JupyterLab Language Packs Bot"
-          git config --global user.email 'krassowski@users.noreply.github.com'
+          git config user.email 'jupyterlab-bot@users.noreply.github.com'
       - name: Commit changes
         run: |
           git add *.pot
@@ -36,7 +39,7 @@ jobs:
           git push --set-upstream origin "${{ env.BRANCH_NAME }}"
       - name: Create a PR
         run: |
-          hub pull-request -m "Update pot files"
+          hub pull-request -m "Update pot files" -m "New changes to pot files were detected."
         env:
           GITHUB_USER: ${{ secrets.GITHUB_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #26

The workflow runs on:
- manual dispatch
- changes to `repository-map.yml` on master

The pot files are updated on CI and then the bot creates a new branch named `pot-update-{short hash of last commit}` and opens a PR with these updates. The bot's PR includes a link to the most recent commit in message. The commiter ID is set to jupyterlab-bot, but the actual PR gets opened by github-actions bot. If no changes are found the job aborts.

For example:
- after merging this test PR: https://github.com/krassowski/language-packs/pull/13 to master
- [this build]( https://github.com/krassowski/language-packs/runs/3014144054) got triggered
- resulting in this bot PR: https://github.com/krassowski/language-packs/pull/14