### PR TITLE
Add permissions necessary for the bot

### DIFF
--- a/.github/workflows/update_pot.yml
+++ b/.github/workflows/update_pot.yml
@@ -6,6 +6,10 @@ on:
       - repository-map.yml
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_pot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tested on my fork, both of these are required as we have organization-wide default to read-only permissions. @fcollonval switched the master to protected so we should be fine.