### PR TITLE
Add `verbose` and `skip-existing` flags to upload

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -95,4 +95,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         cd ${{ env.CURRENT_LOCALE_DIR }}
-        python -m twine upload dist/*
+        python -m twine upload dist/* --verbose --skip-existing


### PR DESCRIPTION
https://github.com/jupyterlab/language-packs/actions/runs/1154161517 had failures for some language packs which appear to be a result of temporary PyPI unavability or us publishing too many packages at once. In order to understand the error better I added `--verbose` and to enable re-running all jobs in case of sporadic failures in future I added `--skip-existing`.