### PR TITLE
Use bash shell in `release_publish.yml`

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -93,6 +93,7 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      shell: bash
       run: |
         cd ${{ env.CURRENT_LOCALE_DIR }}
         counter=0


### PR DESCRIPTION
The previous attempt failed presumable due to use of non-bash shell on GHA.