### PR TITLE
Bump JupyterLab version to 4.0.10

### DIFF
--- a/repository-map.yml
+++ b/repository-map.yml
@@ -15,7 +15,7 @@ jupyter-resource-usage:
   supported-versions: '>=0.6.4'
   url: https://github.com/jupyter-server/jupyter-resource-usage
 jupyterlab:
-  current-version-tag: v4.0.9
+  current-version-tag: v4.0.10
   supported-versions: 4.0.x
   url: https://github.com/jupyterlab/jupyterlab
 jupyterlab-git:


### PR DESCRIPTION
This is to allow translators to start translating the new scrolling behaviour option from https://github.com/jupyterlab/jupyterlab/pull/15565