### PR TITLE
Fix upload artifacts in release_publish.yml

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Upload language pack artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: pip_packages
+        name: py-package-${{ matrix.locale }}
         path: dist/*
     - name: Create Release
       if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skipRelease == 'false' }}
@@ -123,8 +123,9 @@ jobs:
       - name: Get the artifacts
         uses: actions/download-artifact@v4
         with:
-          name: pip_packages
           path: dist
+          pattern: py-package-*
+          merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
actions/upload-artifact@v4 does not allow to merge artifacts any longer:

https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact

This fixes the publication workflow.