### PR TITLE
Fix looking for jupyterlab release

### DIFF
--- a/scripts/01_check_releases.py
+++ b/scripts/01_check_releases.py
@@ -64,9 +64,9 @@ if __name__ == "__main__":
         if match is not None:
             repo = match.groupdict()
 
-            # For JupyterLab we filter explicitly to catch version belonging to minor range
+            # For JupyterLab we filter explicitly to catch version belonging to major range
             ref_filter = (
-                f"v{current_version.major}.{current_version.minor}"
+                f"v{current_version.major}."
                 if package_name == "jupyterlab"
                 else None
             )


### PR DESCRIPTION
The current github ref filter for JupyterLab is inconsistent with the version range. This is the reason this repository has not picked the 4.3.x branch.

This change will pick all "v4." tags.